### PR TITLE
Ensure :error-handler is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cljs-rest: A ClojureScript REST client
 
-`[cljs-rest "0.1.1"]`
+`[cljs-rest "0.1.2"]`
 
 A ClojureScript REST client, suitable for AJAX interaction with RESTful APIs.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-rest "0.1.1"
+(defproject cljs-rest "0.1.2"
   :license {:name "BSD 2-clause \"Simplified\" License"
             :url "http://opensource.org/licenses/BSD-2-Clause"
             :year 2016

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -42,10 +42,11 @@
 
 (defn request [url opts]
   (let [chan (chan)
+        opts* (request-options url opts)
         {:keys [error-handler process]
-         :or {error-handler identity process identity}} opts]
+         :or {error-handler identity process identity}} opts*]
     (ajax/ajax-request
-      (assoc (request-options url opts)
+      (assoc opts*
         :handler (fn [[ok? data :as x]]
                    (when-not ok?
                      (error-handler data))


### PR DESCRIPTION
It would work when provided directly, but not in the default `*opts*` map.