### PR TITLE
Bug fixes: instance error url, multiple listing constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cljs-rest: A ClojureScript REST client
 
-`[cljs-rest "0.1.3"]`
+`[cljs-rest "0.1.4"]`
 
 A ClojureScript REST client, suitable for AJAX interaction with RESTful APIs.
 
@@ -100,6 +100,9 @@ If any step in the async sequence returns an instance of `Error`, that will be t
 
 ### Releases
 
+- 0.1.4
+    - Fixed an issue where requests for `Resource` instances would drop `:url`
+    - Fixed an issue where reading multiple times from a `ResourceListing` with a `:constructor` specified would corrupt results
 - 0.1.3 - Any step in `async->` returning an instance of `Error` will short-circuit the chain
 - 0.1.2 - Bugfix: when present, `:error-handler` in `cljs-rest.core/*opts*` will be called for error responses
 - 0.1.1 - `FormData` payloads are automatically sent as `multipart/form-data`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-rest "0.1.3"
+(defproject cljs-rest "0.1.4"
   :license {:name "BSD 2-clause \"Simplified\" License"
             :url "http://opensource.org/licenses/BSD-2-Clause"
             :year 2016

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -112,9 +112,11 @@
   RestfulInstance
   (instance-constructor [_]
     (fn [[ok? item]]
-      (let [constructed (constructor item)
-            url (:url constructed)]
-        (Resource. url opts constructor ok? constructed))))
+      (if ok?
+          (let [constructed (constructor item)
+                url (:url constructed)]
+            (Resource. url opts constructor ok? constructed))
+          (Resource. url opts constructor ok? item))))
 
   Restful
   (head [_]
@@ -171,8 +173,8 @@
   (items-constructor [this]
     (fn [[ok? data]]
       (if ok?
-          (let [constructor (item-constructor this)
-                constructed (map #(constructor [ok? %]) data)]
+          (let [constructor* (item-constructor this)
+                constructed (map #(constructor* [ok? %]) data)]
             (ResourceListing. url opts item-opts constructor ok? constructed))
           (ResourceListing. url opts item-opts constructor ok? data))))
 


### PR DESCRIPTION
Fixes two issues:

1. `Resource` drops `:url` value in the case of a response error
2. `ResourceListing` with `:constructor` specified corrupts results on subsequent requests