### PR TITLE
Parse `Link` header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cljs-rest: A ClojureScript REST client
 
-`[cljs-rest "1.0.0"]`
+`[cljs-rest "1.1.0"]`
 
 A ClojureScript REST client, suitable for AJAX interaction with RESTful APIs.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ A ClojureScript REST client, suitable for AJAX interaction with RESTful APIs.
   (<! (rest/delete! entry-1)))
 ```
 
+### Link headers
+
+If your REST server returns `Link` headers for pagination, those headers are automatically parsed:
+
+```clojure
+(go
+  (let [resources (<! (rest/get entries {:per_page 10 :page 3}))
+        link (get-in resources [:headers :link])]
+    link
+    ;; {:prev "https://api.whatever.org/entries/?per_page=10&page=2"
+    ;;  :next "https://api.whatever.org/entries/?per_page=10&page=4"}
+
+    (meta link)
+    ;; {:prev {:per_page "10" :page "2"}
+    ;;  :next {:per_page "10" :page "4"}}
+    ))
+```
+
 ### Ajax Options
 
 Options are accepted from an `:opts` keyword argument. Refer to [cljs-http](https://github.com/r0man/cljs-http) for options documentation.
@@ -102,7 +120,7 @@ If any step in the async sequence returns an instance of `Error`, that will be t
 
 ### Releases
 
-- 1.1.0 - `:link` header is parsed into a map
+- 1.1.0 - `:link` header is parsed
 - 1.0.0 - Full rewrite, see the [migration guide](docs/migration_guide_1.0.0.md)
     - Each resource type now populates the following response data:
         - `success`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If any step in the async sequence returns an instance of `Error`, that will be t
 
 ### Releases
 
+- 1.1.0 - `:link` header is parsed into a map
 - 1.0.0 - Full rewrite, see the [migration guide](docs/migration_guide_1.0.0.md)
     - Each resource type now populates the following response data:
         - `success`

--- a/README.md
+++ b/README.md
@@ -49,15 +49,12 @@ If your REST server returns `Link` headers for pagination, those headers are aut
 
 ```clojure
 (go
-  (let [resources (<! (rest/get entries {:per_page 10 :page 3}))
-        link (get-in resources [:headers :link])]
-    link
-    ;; {:prev "https://api.whatever.org/entries/?per_page=10&page=2"
-    ;;  :next "https://api.whatever.org/entries/?per_page=10&page=4"}
-
-    (meta link)
-    ;; {:prev {:per_page "10" :page "2"}
-    ;;  :next {:per_page "10" :page "4"}}
+  (let [resources (<! (rest/get entries {:per_page 10 :page 3}))]
+    (get-in resources [:headers :link])
+    ;; {:prev {:url "https://api.whatever.org/entries/?per_page=10&page=2"
+    ;;         :params {:per_page "10" :page "2"}}
+    ;;  :next {:url "https://api.whatever.org/entries/?per_page=10&page=4"
+    ;;         :params {:per_page "10" :page "4"}}}
     ))
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-rest "1.0.0"
+(defproject cljs-rest "1.1.0"
   :license {:name "BSD 2-clause \"Simplified\" License"
             :url "http://opensource.org/licenses/BSD-2-Clause"
             :year 2016

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -121,21 +121,21 @@
 (def link-pattern
   #"<(.*?)>; rel=\"(.*?)\"")
 
-(defn parse-link [headers]
-  (if-let [link (:link headers)]
-    (let [matches (re-seq link-pattern link)
-          link* (reduce
-                  (fn [acc [_ url key-str]]
-                    (assoc acc (keyword key-str) url))
-                  {}
-                  matches)]
-      (assoc headers :link link*))
-    headers))
+(defn expand-link [link]
+  (when link
+    (let [matches (re-seq link-pattern link)]
+      (if (empty? matches)
+          link
+          (reduce
+            (fn [acc [_ url key-str]]
+              (assoc acc (keyword key-str) url))
+            {}
+            matches)))))
 
 (defn expand-headers [headers]
   (-> headers
       with-keywords
-      parse-link))
+      (update :link expand-link)))
 
 (defn request
   ([url] (request url {}))

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -120,7 +120,10 @@
     m))
 
 (def link-pattern
-  #"(?i)<(.*?)>; rel=\"(.*?)\"")
+  "Matches a `link-value` according to https://tools.ietf.org/html/rfc5988#section-5,
+  capturing `URI-Reference` and a `rel` value for `link-param`, ignoring all other
+  `link-param` fields if present."
+  #"(?i)<(.*?)>(?:;\s*(?!rel)[^=]+=\".*?\")*;\s*rel=\"(.*?)\"(?:;\s*[^=]+=\".*?\")*")
 
 (defn parse-url-query-params [url]
   (let [uri (uri/parse url)

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -120,7 +120,7 @@
     m))
 
 (def link-pattern
-  #"<(.*?)>; rel=\"(.*?)\"")
+  #"(?i)<(.*?)>; rel=\"(.*?)\"")
 
 (defn parse-url-query-params [url]
   (let [uri (uri/parse url)

--- a/src/cljs_rest/core.cljs
+++ b/src/cljs_rest/core.cljs
@@ -136,9 +136,12 @@
           (reduce
             (fn [acc [_ url key-str]]
               (let [k (keyword key-str)
-                    with-url (assoc acc k url)
-                    query-params (parse-url-query-params url)]
-                (vary-meta with-url assoc k query-params)))
+                    params (parse-url-query-params url)
+                    parsed {:url url}
+                    with-params (if (empty? params)
+                                    parsed
+                                    (assoc parsed :params params))]
+                (assoc acc k with-params)))
             {}
             matches)))))
 

--- a/test/cljs_rest/core_test.cljs
+++ b/test/cljs_rest/core_test.cljs
@@ -99,7 +99,7 @@
 (deftest listing-read-params
   (async done
     (go
-      (let [resources (<! (rest/get listing {:empty "results"}))]
+      (let [resources (<! (rest/get listing {:per-page 0}))]
         (is (= (list) (:resources resources)))
         (done)))))
 
@@ -134,7 +134,7 @@
 (deftest listing-first-resource-empty-error
   (async done
     (go
-      (let [resource (<! (rest/first-resource listing {:empty "results"}))]
+      (let [resource (<! (rest/first-resource listing {:per-page 0}))]
         (is (= false (:success resource)))
         (is (= 404 (:status resource)))
         (done)))))
@@ -143,7 +143,7 @@
   (async done
     (go
       (let [error-chan (configure-error-chan!)
-            resources (<! (rest/first-resource listing {:empty "results"}))
+            resources (<! (rest/first-resource listing {:per-page 0}))
             error (<! error-chan)]
         (is (= false (:success error)))
         (is (= 404 (:status error)))

--- a/test/cljs_rest/core_test.cljs
+++ b/test/cljs_rest/core_test.cljs
@@ -191,6 +191,17 @@
         (is (= expected data))
         (done)))))
 
+(deftest listing-parse-link-header
+  (async done
+    (go
+      (let [payload (first payloads)
+            third-resource (<! (rest/post! listing payload))
+            resources (<! (rest/get listing {:per-page 1 :page 2}))
+            expected {:prev "/entries/?per-page=1&page=1"
+                      :next "/entries/?per-page=1&page=3"}]
+        (is (= expected (get-in resources [:headers :link])))
+        (done)))))
+
 (deftest instance-read
   (async done
     (go
@@ -215,7 +226,7 @@
 (deftest instance-error
   (async done
     (go
-      (let [url (item-url 3)
+      (let [url (item-url 420)
             resource (rest/resource url)
             instance (<! (rest/get resource))]
         (is (= false (:success instance)))
@@ -225,7 +236,7 @@
 (deftest instance-error-retains-url
   (async done
     (go
-      (let [url (item-url 3)
+      (let [url (item-url 420)
             resource (rest/resource url)
             instance (<! (rest/get resource))]
         (is (= url (:url instance)))
@@ -299,7 +310,7 @@
                        listing
                        rest/get
                        :resources
-                       last
+                       second
                        (rest/put! payload)
                        :data))
             expected {:url (item-url 2)}]

--- a/test/cljs_rest/core_test.cljs
+++ b/test/cljs_rest/core_test.cljs
@@ -191,17 +191,6 @@
         (is (= expected data))
         (done)))))
 
-(deftest listing-parse-link-header
-  (async done
-    (go
-      (let [payload (first payloads)
-            third-resource (<! (rest/post! listing payload))
-            resources (<! (rest/get listing {:per-page 1 :page 2}))
-            expected {:prev "/entries/?per-page=1&page=1"
-                      :next "/entries/?per-page=1&page=3"}]
-        (is (= expected (get-in resources [:headers :link])))
-        (done)))))
-
 (deftest instance-read
   (async done
     (go
@@ -298,6 +287,31 @@
             resources (<! (rest/get listing))
             error (<! error-chan)]
         (is (= 404 (:status error)))
+        (done)))))
+
+(deftest parse-link-header
+  (async done
+    (go
+      (let [payload (first payloads)
+            third-resource (<! (rest/post! listing payload))
+            resources (<! (rest/get listing {:per-page 1 :page 2}))
+            expected {:prev "/entries/?per-page=1&page=1"
+                      :next "/entries/?per-page=1&page=3"}]
+        (is (= expected (get-in resources [:headers :link])))
+        (done)))))
+
+(deftest parse-link-header-params
+  (async done
+    (go
+      (let [payload (first payloads)
+            third-resource (<! (rest/post! listing payload))
+            resources (<! (rest/get listing {:per-page 1 :page 2}))
+            expected {:prev {:per-page "1"
+                             :page "1"}
+                      :next {:per-page "1"
+                             :page "3"}}
+            link (get-in resources [:headers :link])]
+        (is (= expected (meta link)))
         (done)))))
 
 ;; Async threading

--- a/test/cljs_rest/core_test.cljs
+++ b/test/cljs_rest/core_test.cljs
@@ -295,23 +295,13 @@
       (let [payload (first payloads)
             third-resource (<! (rest/post! listing payload))
             resources (<! (rest/get listing {:per-page 1 :page 2}))
-            expected {:prev "/entries/?per-page=1&page=1"
-                      :next "/entries/?per-page=1&page=3"}]
+            expected {:prev {:url "/entries/?per-page=1&page=1"
+                             :params {:per-page "1"
+                                      :page "1"}}
+                      :next {:url "/entries/?per-page=1&page=3"
+                             :params {:per-page "1"
+                                      :page "3"}}}]
         (is (= expected (get-in resources [:headers :link])))
-        (done)))))
-
-(deftest parse-link-header-params
-  (async done
-    (go
-      (let [payload (first payloads)
-            third-resource (<! (rest/post! listing payload))
-            resources (<! (rest/get listing {:per-page 1 :page 2}))
-            expected {:prev {:per-page "1"
-                             :page "1"}
-                      :next {:per-page "1"
-                             :page "3"}}
-            link (get-in resources [:headers :link])]
-        (is (= expected (meta link)))
         (done)))))
 
 ;; Async threading

--- a/test/cljs_rest/mock_server.cljs
+++ b/test/cljs_rest/mock_server.cljs
@@ -101,7 +101,8 @@
          (take per-page))))
 
 (defn pagination-url [base-url per-page page]
-  (str base-url "?" (http/generate-query-string {:per-page per-page :page page})))
+  ;; Hard-coded as a string for guaranteed order
+  (str base-url "?per-page=" per-page "&page=" page))
 
 (defn link-header [links]
   (string/join ", "
@@ -120,7 +121,7 @@
         next (when (> total (+ skip per-page))
                (pagination-url base-url per-page (inc page)))
         link-header (link-header {:prev prev :next next})]
-    (when link-header
+    (when-not (empty? link-header)
       {"link" link-header})))
 
 (defmethod request [:get :entries] [req]


### PR DESCRIPTION
If present, `Link` response headers will be parsed. This attempts to match arbitrary `link-value`s according to [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5), but only accounts for the `rel` `link-param`, as its value is used as a key in the generated map.

Depends on #10 for testing.
